### PR TITLE
Added logMessage prop

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,6 +35,9 @@ class AWSIOTProvider extends Component {
     this.client.publish(this.props.iotTopic, message); // send messages
   }
   onMessage(topic, message) {
+    if (this.props.logMessage) {
+      this.props.logMessage(message);
+    }
     this.setState({ message, topic });
   }
   onClose(topic) {
@@ -57,13 +60,15 @@ AWSIOTProvider.propTypes = {
   accessKey: PropTypes.string.isRequired,
   secretKey: PropTypes.string.isRequired,
   sessionToken: PropTypes.string.isRequired,
-  iotEndpoint: PropTypes.string.isRequired
+  iotEndpoint: PropTypes.string.isRequired,
+  logMessage: PropTypes.func
 };
 AWSIOTProvider.defaultProps = {
   region: "",
   accessKey: "",
   secretKey: "",
   sessionToken: "",
-  iotEndpoint: ""
+  iotEndpoint: "",
+  logMessage: null
 };
 export { AWSIOTProvider, Consumer as AWSIOTConsumer };


### PR DESCRIPTION
### Use Case
I want to be able to see that my application is receiving IOT events  without having to drill down into `react-aws-iot-provider`

Using a prop function so that this package doesn't need to introduce any logging implementation or 3rd party support. Downstream code can determine how logging needs to be done